### PR TITLE
bugfix/pagination

### DIFF
--- a/src/app-components/pager.js
+++ b/src/app-components/pager.js
@@ -10,7 +10,7 @@ const Page = ({ pageNo, isCurrent, onClick }) => {
   return (
     <li className={pageClass} onClick={onClick}>
       <a className="page-link" aria-label={`Goto page ${pageNo}`}>
-        {pageNo}
+        {pageNo + 1}
       </a>
     </li>
   );
@@ -70,53 +70,14 @@ export default ({ items, pageSize, children, itemsKey }) => {
               «
             </a>
           </li>
-
-          <Page
-            pageNo={1}
-            isCurrent={currentPage === 0}
-            onClick={() => {
-              setPage(0);
-            }}
-          />
-
-          {currentPage > 2 && pages.length > 5 ? (
-            <li className="page-item">
-              <span className="page-link">…</span>
-            </li>
-          ) : null}
-
-          {[1, 2, 3].map((_, i) => {
-            let p1 = currentPage - 1;
-            // if current page is 0, or 1 we start the count at idx = 1
-            if (currentPage <= 1) p1 = 1;
-            // if current page is greater than length - 2 we start the idx at length - 4
-            if (currentPage >= pages.length - 2) p1 = pages.length - 4;
-            return (
-              <Page
-                key={`${i}-${p1}`}
-                pageNo={p1 + i + 1}
-                isCurrent={currentPage === p1 + i}
-                onClick={() => {
-                  setPage(p1 + i);
-                }}
-              />
-            );
-          })}
-
-          {currentPage < pages.length - 2 && pages.length > 5 ? (
-            <li className="page-item">
-              <span className="page-link">…</span>
-            </li>
-          ) : null}
-
-          <Page
-            pageNo={pages.length}
-            isCurrent={currentPage === pages.length - 1}
-            onClick={() => {
-              setPage(pages.length - 1);
-            }}
-          />
-
+          {pages.map((_page, i) => (
+            <Page
+              key={`page-${i}`}
+              pageNo={i}
+              isCurrent={currentPage === i}
+              onClick={() => setPage(i)}
+            />
+          ))}
           <li className="page-item" onClick={pageUp}>
             <a className="page-link" aria-label={`Go to next page`}>
               »

--- a/src/app-components/pager.js
+++ b/src/app-components/pager.js
@@ -45,27 +45,13 @@ const determinePagesToShow = (pages, currentPage, setPage) => {
 
     for (let i = -1; i < 2; i++) {
       if (currentPage + i > 0 && currentPage + i < pages.length - 1)
-        ret.push(
-          <Page
-            key={`page-${currentPage + i}`}
-            pageNo={currentPage + i}
-            isCurrent={currentPage === currentPage + i}
-            onClick={() => setPage(currentPage + i)}
-          />
-        );
+        ret.push(createPage(currentPage, setPage, currentPage + i));
     }
 
     if (currentPage < pages.length - 3) ret.push(<Ellipsis />);
     return ret;
   } else if (pages.length >= 3) {
-    return pages.slice(1, pages.length - 1).map((_page, i) => (
-      <Page
-        key={`page-${i + 1}`}
-        pageNo={i + 1}
-        isCurrent={currentPage === i + 1}
-        onClick={() => setPage(i + 1)}
-      />
-    ))
+    return pages.slice(1, pages.length - 1).map((_page, i) => createPage(currentPage, setPage, i + i));
   }
 
   return null;
@@ -127,24 +113,14 @@ const Pagination = ({ items, pageSize, children, itemsKey }) => {
           </li>
 
           {/* Always show Page 1 (index 0) */}
-          <Page
-            key={`page-${0}`}
-            pageNo={0}
-            isCurrent={currentPage === 0}
-            onClick={() => setPage(0)}
-          />
+          {createPage(currentPage, setPage, 0)}
 
           {/* Determine middle pages to show */}
           {determinePagesToShow(pages, currentPage, setPage)}
 
           {/* Show Last Page if more than 1 page (index pages.length - 1) */}
           {pages.length > 1 && (
-            <Page
-              key={`page-${pages.length - 1}`}
-              pageNo={pages.length - 1}
-              isCurrent={currentPage === pages.length - 1}
-              onClick={() => setPage(pages.length - 1)}
-            />
+            createPage(currentPage, setPage, pages.length - 1)
           )}
 
           <li className="page-item" onClick={pageUp}>


### PR DESCRIPTION
Opening PR in response to https://github.com/USACE/instrumentation-ui/issues/18

Changes made:
- change page 0 -> page 1, as consumers do not reference pages as a 0-index as developers do.
- map over created pages to determine number of actionable buttons to display in the pagination control and associated ellipsis.
  - special cases for first and last pages to show an extra page after or before, respectively.

@brettpalmberg - Can you pull down this branch (`bugfix/pagination`) and verify the issue you were seeing is resolved?

Will wait for confirmation before proceeding with merge.