### PR TITLE
Limit Timeseries_Id to Current Project

### DIFF
--- a/src/app-components/pager.js
+++ b/src/app-components/pager.js
@@ -36,19 +36,19 @@ const determinePagesToShow = (pages, currentPage, setPage) => {
   const ret = [];
   if (pages.length > 6) {
     if (currentPage === 0) {
-      return [createPage(currentPage, setPage, 1), createPage(currentPage, setPage, 2), <Ellipsis key='ellipsis' />];
+      return [createPage(currentPage, setPage, 1), createPage(currentPage, setPage, 2), <Ellipsis key='ellipsis-0' />];
     }
     if (currentPage === pages.length - 1) {
-      return [<Ellipsis key='ellipsis' />, createPage(currentPage, setPage, currentPage - 2), createPage(currentPage, setPage, currentPage - 1)];
+      return [<Ellipsis key='ellipsis-1' />, createPage(currentPage, setPage, currentPage - 2), createPage(currentPage, setPage, currentPage - 1)];
     }
-    if (currentPage > 2) ret.push(<Ellipsis key='ellipsis' />);
+    if (currentPage > 2) ret.push(<Ellipsis key='ellipsis-2' />);
 
     for (let i = -1; i < 2; i++) {
       if (currentPage + i > 0 && currentPage + i < pages.length - 1)
         ret.push(createPage(currentPage, setPage, currentPage + i));
     }
 
-    if (currentPage < pages.length - 3) ret.push(<Ellipsis  key='ellipsis' />);
+    if (currentPage < pages.length - 3) ret.push(<Ellipsis  key='ellipsis-3' />);
     return ret;
   } else if (pages.length >= 3) {
     return pages.slice(1, pages.length - 1).map((_page, i) => createPage(currentPage, setPage, i + i));

--- a/src/app-components/pager.js
+++ b/src/app-components/pager.js
@@ -36,19 +36,19 @@ const determinePagesToShow = (pages, currentPage, setPage) => {
   const ret = [];
   if (pages.length > 6) {
     if (currentPage === 0) {
-      return [createPage(currentPage, setPage, 1), createPage(currentPage, setPage, 2), <Ellipsis />];
+      return [createPage(currentPage, setPage, 1), createPage(currentPage, setPage, 2), <Ellipsis key='ellipsis' />];
     }
     if (currentPage === pages.length - 1) {
-      return [<Ellipsis />, createPage(currentPage, setPage, currentPage - 2), createPage(currentPage, setPage, currentPage - 1)];
+      return [<Ellipsis key='ellipsis' />, createPage(currentPage, setPage, currentPage - 2), createPage(currentPage, setPage, currentPage - 1)];
     }
-    if (currentPage > 2) ret.push(<Ellipsis />);
+    if (currentPage > 2) ret.push(<Ellipsis key='ellipsis' />);
 
     for (let i = -1; i < 2; i++) {
       if (currentPage + i > 0 && currentPage + i < pages.length - 1)
         ret.push(createPage(currentPage, setPage, currentPage + i));
     }
 
-    if (currentPage < pages.length - 3) ret.push(<Ellipsis />);
+    if (currentPage < pages.length - 3) ret.push(<Ellipsis  key='ellipsis' />);
     return ret;
   } else if (pages.length >= 3) {
     return pages.slice(1, pages.length - 1).map((_page, i) => createPage(currentPage, setPage, i + i));

--- a/src/upload-parsers/timeseries_measurements.js
+++ b/src/upload-parsers/timeseries_measurements.js
@@ -36,14 +36,18 @@ const timeseriesMeasurementParser = {
       type: 'internal',
       required: true,
       useFilterComponent: true,
-      provider: state => (
-        Object.keys(state.instrumentTimeseries)
-          .filter(key => key.charAt(0) !== '_')
+      provider: state => {
+        const regex = new RegExp('/projects/(.*)/instruments');
+        const match = state.instruments._lastResource.match(regex);
+        const projectId = match && match.length >= 2 ? match[1] : '';
+
+        return Object.keys(state.instrumentTimeseries)
+          .filter(key => (key.charAt(0) !== '_' && state.instrumentTimeseries[key].project_id === projectId))
           .map(key => ({
             value: key,
             text: `${state.instrumentTimeseries[key].instrument} - ${state.instrumentTimeseries[key].name}`,
-          }))
-      ),
+          }));
+      },
       parse: val => val,
       validate: val => !!val,
       helpText: 'Should map to an timeseries name that exists in the system for the selected instrument.',


### PR DESCRIPTION
- In timeseries measurements uploader, limit the timeseries that gets displayed in the list to only those that apply to the current project.

- React key improvements on Pagination component.