### PR TITLE
images fetched from api

### DIFF
--- a/src/app-bundles/projects-bundle.js
+++ b/src/app-bundles/projects-bundle.js
@@ -1,10 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
 import { createSelector } from "redux-bundler";
-import bird from "../img/florida-bird.jpg";
-import dam from "../img/dam.jpg";
-import moosecreek from "../img/moosecreek.png";
-import mountmorris from "../img/mountmorris.jpg";
-import indianaharbor from "../img/indianaharbor.jpg";
 
 export default createRestBundle({
   name: "projects",
@@ -34,16 +29,7 @@ export default createRestBundle({
       (projects) => {
         return projects.map((p) => {
           return {
-            img:
-              p.name.indexOf("Moose Creek") !== -1
-                ? moosecreek
-                : p.name.indexOf("Buffalo District Streamgages") !== -1
-                ? mountmorris
-                : p.name.indexOf("Indiana") !== -1
-                ? indianaharbor
-                : p.name.indexOf("Dam") !== -1
-                ? dam
-                : bird,
+            img: p.image,
             title: p.name,
             subtitle: "Instrumentation Browser",
             href: `/${p.slug}/manager`,

--- a/src/app-pages/home/project-card.js
+++ b/src/app-pages/home/project-card.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
 const ProjectCard = ({ project }) => {
   const { img, title, subtitle, href } = project;
@@ -12,28 +12,31 @@ const ProjectCard = ({ project }) => {
   };
 
   return (
-    <a href={href} tabIndex={0}>
-      <div className='card mb-5' style={{ maxWidth: '300px' }}>
-        <button className='favorite' onClick={toggleFavorite}>
-          <span
-            className={`mdi ${
-              isFavorite ? 'mdi-star gold' : 'mdi-star-outline'
-            }`}
-          />
-        </button>
-        {img ? (
-          <img
-            style={{ height: '200px', width: '100%', display: 'block' }}
-            src={img}
-            alt='Pretty scene associated with the project'
-          />
-        ) : null}
-        <div className='card-body'>
-          <h5 className='card-title overflow-ellipsis'>{title}</h5>
-          <h6 className='card-subtitle text-muted'>{subtitle}</h6>
+    <>
+      <a href={href} tabIndex={0}>
+        <div className="card mb-5" style={{ maxWidth: "300px" }}>
+          <button className="favorite" onClick={toggleFavorite}>
+            <span
+              className={`mdi ${
+                isFavorite ? "mdi-star gold" : "mdi-star-outline"
+              }`}
+            />
+          </button>
+          {img ? (
+            <img
+              style={{ height: "200px", width: "100%", display: "block" }}
+              src={img}
+              alt="Pretty scene associated with the project"
+            />
+          ) : null}
+
+          <div className="card-body">
+            <h5 className="card-title overflow-ellipsis">{title}</h5>
+            <h6 className="card-subtitle text-muted">{subtitle}</h6>
+          </div>
         </div>
-      </div>
-    </a>
+      </a>
+    </>
   );
 };
 


### PR DESCRIPTION
Project Card Images now take advantage of fetching project images from the API and can be removed from source control.  Related to changes in the api discussed here: USACE/instrumentation#9.

NOTE: The RESTful api in dev has been moved to: `https://api2.rsgis.dev/instrumentation`, which implements the new image service (see commit https://github.com/USACE/instrumentation-ui/commit/0b78d8e8f531e12a14a30b157c42afe4febba648)

Closes USACE/instrumentation#9

cc @KevinJJackson @thill02