### PR TITLE
check for bad item.latest_time before date parse

### DIFF
--- a/src/app-pages/collectiongroup/collectiongroup-timeseries-list.js
+++ b/src/app-pages/collectiongroup/collectiongroup-timeseries-list.js
@@ -49,7 +49,7 @@ const TimeseriesListEntry = ({
             </small>
           </div>
           <div className='text-secondary font-weight-light font-italic'>
-            {formatDistanceToNow(parseISO(item.latest_time)) + ' ago'}
+            {item.latest_time != null ? formatDistanceToNow(parseISO(item.latest_time)) + ' ago' : 'No Data Found'}
           </div>
         </div>
         {/* Column 3 */}

--- a/src/app-pages/collectiongroup/collectiongroup-timeseries-list.js
+++ b/src/app-pages/collectiongroup/collectiongroup-timeseries-list.js
@@ -49,7 +49,7 @@ const TimeseriesListEntry = ({
             </small>
           </div>
           <div className='text-secondary font-weight-light font-italic'>
-            {item.latest_time != null ? formatDistanceToNow(parseISO(item.latest_time)) + ' ago' : 'No Data Found'}
+            {item.latest_time ? formatDistanceToNow(parseISO(item.latest_time)) + ' ago' : 'No Data Found'}
           </div>
         </div>
         {/* Column 3 */}


### PR DESCRIPTION
Prevents application crashes due to a user adding/viewing a timeseries without data to a collection group.