### PR TITLE
Enhancement/filter-multi-select

### DIFF
--- a/src/app-components/button.js
+++ b/src/app-components/button.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { classArray } from '../utils';
+
 /**
  * 
  * @param {string} size - one of `['small', 'large']` to size the button to your needs
@@ -28,13 +30,13 @@ const Button = ({
   ...customProps
 }) => {
   const elem = href ? 'a' : 'button';
-  const classes = [
+  const classes = classArray([
     'btn',
     size && size === 'small' ? 'btn-sm' : size === 'large' ? 'btn-lg' : '',
     `btn-${isOutline ? 'outline-' : ''}${variant}`,
     isDisabled && 'disabled not-allowed',
     className,
-  ].filter(e => e).join(' ');
+  ]);
 
   const buttonProps = {
     className: classes,

--- a/src/app-components/dropdown.js
+++ b/src/app-components/dropdown.js
@@ -1,4 +1,4 @@
-import React, { createContext, useRef, useState } from 'react';
+import React, { createContext, useEffect, useRef, useState } from 'react';
 
 import useOutsideEventHandle from '../customHooks/useOutsideEventHandle';
 import useWindowListener from '../customHooks/useWindowListener';
@@ -42,6 +42,7 @@ const Dropdown = ({
   customContent = null,
   children = null,
   closeWithEscape = true,
+  onToggle = () => {},
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef(null);
@@ -57,6 +58,10 @@ const Dropdown = ({
       setIsOpen(false);
     }
   });
+
+  useEffect(() => {
+    onToggle(isOpen);
+  }, [isOpen, onToggle]);
 
   const commonProps = {
     onClick: () => setIsOpen(!isOpen),

--- a/src/app-components/filter-select.js
+++ b/src/app-components/filter-select.js
@@ -34,7 +34,7 @@ const FilterSelect = ({
       const newSet = items.filter(elem => {
         const val = getDisplay(elem);
 
-        return (val.toLowerCase()).indexOf(inputVal.toLowerCase()) !== -1;
+        return (String(val).toLowerCase()).indexOf(inputVal.toLowerCase()) !== -1;
       });
 
       setFilteredList(newSet);

--- a/src/app-components/multi-select.js
+++ b/src/app-components/multi-select.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import Button from './button';
 import Dropdown from './dropdown';
 
 const reduceSelections = (selection, currentSelections) => {
@@ -24,6 +25,16 @@ const generateOption = (option, handleClick, optionIsSelected, i) => {
   );
 };
 
+const FilterInput = () => (
+  <input
+    className='form-control'
+    autoFocus
+    placeholder='Filter List...'
+    // THIS IS BEING OVERRIDDEN BY DROPDOWN, FIGURE OUT A LOOPHOLE
+    onClick={e => e.stopPropagation()}
+  />
+);
+
 const MultiSelect = ({
   text = 'Select Options',
   className = '',
@@ -31,10 +42,12 @@ const MultiSelect = ({
   onChange = () => {},
   options = [],
   withSelectAllOption = false,
-  initialValues = []
+  initialValues = [],
+  isFilterable = false,
 }) => {
   const [currentSelections, setCurrentSelections] = useState(initialValues);
   const [isAllSelected, setIsAllSelected] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const handleSelectAll = () => {
     if (isAllSelected) {
@@ -57,11 +70,13 @@ const MultiSelect = ({
 
   return (
     <Dropdown.Menu
+      customContent={isFilterable && isDropdownOpen && <FilterInput />}
       dropdownClasses={[className]}
       menuClasses={[menuClasses]}
       buttonContent={<span>{text}&nbsp;</span>}
       buttonClasses={['btn-outline-info']}
       closeOnSelect={false}
+      onToggle={isOpen => setIsDropdownOpen(isOpen)}
     >
       {withSelectAllOption && (
         generateOption({ text: 'Select All' }, handleSelectAll, isAllSelected, 'all')

--- a/src/app-components/multi-select/helper.js
+++ b/src/app-components/multi-select/helper.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import Dropdown from '../dropdown';
+
+export const reduceSelections = (selection, currentSelections) => {
+  const final = [...currentSelections];
+  const idx = currentSelections.findIndex(elem => elem === selection);
+
+  idx < 0 ? final.push(selection) : final.splice(idx, 1);
+
+  return final;
+};
+
+export const generateOption = (option, handleClick, optionIsSelected, i) => {
+  const icon = optionIsSelected ? 'mdi-check-box-outline' : 'mdi-checkbox-blank-outline';
+
+  return (
+    <Dropdown.Item key={i} onClick={(_e) => handleClick()}>
+      <span className={optionIsSelected ? 'text-info' : 'text-dark'}>
+        <i className={`mdi ${icon}`}/>&nbsp;
+        {option.text || option.value}
+      </span>
+    </Dropdown.Item>
+  );
+};

--- a/src/app-components/multi-select/index.js
+++ b/src/app-components/multi-select/index.js
@@ -1,0 +1,1 @@
+export { default } from './multi-select';

--- a/src/app-components/multi-select/multi-select.js
+++ b/src/app-components/multi-select/multi-select.js
@@ -18,13 +18,27 @@ const MultiSelect = ({
   const [isAllSelected, setIsAllSelected] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef();
-  const inputRef = useRef(null);
+  const inputRef = useRef();
 
   const handleSelectAll = () => {
     if (isAllSelected) {
       setCurrentSelections([]);
     } else {
       setCurrentSelections(options.map(elem => elem.value));
+    }
+  };
+
+  const handleOpen = () => {
+    console.log('opening!');
+    if (dropdownRef && dropdownRef.current) {
+      if (!isDropdownOpen) dropdownRef.current.openDropdown();
+    }
+  };
+
+  const handleClose = () => {
+    console.log('closing!');
+    if (dropdownRef && dropdownRef.current) {
+      if (isDropdownOpen) dropdownRef.current.closeDropdown();
     }
   };
 
@@ -37,7 +51,7 @@ const MultiSelect = ({
         setIsAllSelected(false);
       }
     }
-  }, [onChange, currentSelections, setIsAllSelected]);
+  }, [onChange, currentSelections, withSelectAllOption, setIsAllSelected]);
 
   return (
     <Dropdown.Menu
@@ -45,15 +59,13 @@ const MultiSelect = ({
       customContent={(
         <>
           <DropdownButton
-            handleClick={() => {
-              if (dropdownRef && dropdownRef.current) {
-                if (!isDropdownOpen) dropdownRef.current.toggleDropdown();
-              }
-            }}
+            handleClick={handleOpen}
             text={text}
             isHidden={isFilterable && isDropdownOpen}
           />
           <FilterInput
+            onChange={(val) => console.log('input changed! ', val)}
+            handleClose={handleClose}
             isHidden={!isFilterable || (isFilterable && !isDropdownOpen)}
             ref={inputRef}
           />

--- a/src/app-components/multi-select/multi-select.js
+++ b/src/app-components/multi-select/multi-select.js
@@ -1,39 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
-import Button from './button';
-import Dropdown from './dropdown';
-
-const reduceSelections = (selection, currentSelections) => {
-  const final = [...currentSelections];
-  const idx = currentSelections.findIndex(elem => elem === selection);
-
-  idx < 0 ? final.push(selection) : final.splice(idx, 1);
-
-  return final;
-};
-
-const generateOption = (option, handleClick, optionIsSelected, i) => {
-  const icon = optionIsSelected ? 'mdi-check-box-outline' : 'mdi-checkbox-blank-outline';
-
-  return (
-    <Dropdown.Item key={i} onClick={(_e) => handleClick()}>
-      <span className={optionIsSelected ? 'text-info' : 'text-dark'}>
-        <i className={`mdi ${icon}`}/>&nbsp;
-        {option.text || option.value}
-      </span>
-    </Dropdown.Item>
-  );
-};
-
-const FilterInput = () => (
-  <input
-    className='form-control'
-    autoFocus
-    placeholder='Filter List...'
-    // THIS IS BEING OVERRIDDEN BY DROPDOWN, FIGURE OUT A LOOPHOLE
-    onClick={e => e.stopPropagation()}
-  />
-);
+import Dropdown from '../dropdown';
+import { DropdownButton, FilterInput } from './subcomponents';
+import { generateOption, reduceSelections } from './helper';
 
 const MultiSelect = ({
   text = 'Select Options',
@@ -48,6 +17,8 @@ const MultiSelect = ({
   const [currentSelections, setCurrentSelections] = useState(initialValues);
   const [isAllSelected, setIsAllSelected] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const dropdownRef = useRef();
+  const inputRef = useRef(null);
 
   const handleSelectAll = () => {
     if (isAllSelected) {
@@ -70,13 +41,32 @@ const MultiSelect = ({
 
   return (
     <Dropdown.Menu
-      customContent={isFilterable && isDropdownOpen && <FilterInput />}
+      ref={dropdownRef}
+      customContent={(
+        <>
+          <DropdownButton
+            handleClick={() => {
+              if (dropdownRef && dropdownRef.current) {
+                if (!isDropdownOpen) dropdownRef.current.toggleDropdown();
+              }
+            }}
+            text={text}
+            isHidden={isFilterable && isDropdownOpen}
+          />
+          <FilterInput
+            isHidden={!isFilterable || (isFilterable && !isDropdownOpen)}
+            ref={inputRef}
+          />
+        </>
+      )}
       dropdownClasses={[className]}
       menuClasses={[menuClasses]}
-      buttonContent={<span>{text}&nbsp;</span>}
-      buttonClasses={['btn-outline-info']}
       closeOnSelect={false}
       onToggle={isOpen => setIsDropdownOpen(isOpen)}
+      containerRefs={[inputRef]}
+      customElementProps={{
+        onClick: () => {},
+      }}
     >
       {withSelectAllOption && (
         generateOption({ text: 'Select All' }, handleSelectAll, isAllSelected, 'all')

--- a/src/app-components/multi-select/multi-select.js
+++ b/src/app-components/multi-select/multi-select.js
@@ -3,9 +3,15 @@ import React, { useEffect, useState, useRef } from 'react';
 import Dropdown from '../dropdown';
 import { DropdownButton, FilterInput } from './subcomponents';
 import { generateOption, reduceSelections } from './helper';
+import usePrevious from '../../customHooks/usePrevious';
+
+const getDisplay = elem => {
+  const { value, text } = elem;
+  return text ? text : value;
+};
 
 const MultiSelect = ({
-  text = 'Select Options',
+  text = 'Select Options ',
   className = '',
   menuClasses = '',
   onChange = () => {},
@@ -17,6 +23,9 @@ const MultiSelect = ({
   const [currentSelections, setCurrentSelections] = useState(initialValues);
   const [isAllSelected, setIsAllSelected] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [inputValue, setInputValue] = useState('');
+  const previuosInputValue = usePrevious(inputValue);
   const dropdownRef = useRef();
   const inputRef = useRef();
 
@@ -29,14 +38,12 @@ const MultiSelect = ({
   };
 
   const handleOpen = () => {
-    console.log('opening!');
     if (dropdownRef && dropdownRef.current) {
       if (!isDropdownOpen) dropdownRef.current.openDropdown();
     }
   };
 
   const handleClose = () => {
-    console.log('closing!');
     if (dropdownRef && dropdownRef.current) {
       if (isDropdownOpen) dropdownRef.current.closeDropdown();
     }
@@ -53,6 +60,20 @@ const MultiSelect = ({
     }
   }, [onChange, currentSelections, withSelectAllOption, setIsAllSelected]);
 
+  useEffect(() => {
+    if (isFilterable) {
+      if (previuosInputValue !== inputValue) {
+        const newSet = options.filter(elem => {
+          const val = getDisplay(elem);
+  
+          return (String(val).toLowerCase()).indexOf(inputValue.toLowerCase()) !== -1;
+        });
+  
+        setFilteredOptions(newSet);
+      }
+    }
+  }, [isFilterable, previuosInputValue, inputValue]);
+
   return (
     <Dropdown.Menu
       ref={dropdownRef}
@@ -64,7 +85,7 @@ const MultiSelect = ({
             isHidden={isFilterable && isDropdownOpen}
           />
           <FilterInput
-            onChange={(val) => console.log('input changed! ', val)}
+            onChange={val => setInputValue(val)}
             handleClose={handleClose}
             isHidden={!isFilterable || (isFilterable && !isDropdownOpen)}
             ref={inputRef}
@@ -80,15 +101,23 @@ const MultiSelect = ({
         onClick: () => {},
       }}
     >
-      {withSelectAllOption && (
-        generateOption({ text: 'Select All' }, handleSelectAll, isAllSelected, 'all')
-      )}
-      {options.map((option, i) => {
-        const optionIsSelected = currentSelections.find(elem => elem === option.value);
-        const handleClick = () => setCurrentSelections(reduceSelections(option.value, currentSelections));
+      {filteredOptions.length ? (
+        <>
+          {withSelectAllOption && (
+            generateOption({ text: 'Select All' }, handleSelectAll, isAllSelected, 'all')
+          )}
+          {filteredOptions.map((option, i) => {
+            const optionIsSelected = currentSelections.find(elem => elem === option.value);
+            const handleClick = () => setCurrentSelections(reduceSelections(option.value, currentSelections));
 
-        return generateOption(option, handleClick, optionIsSelected, i);
-      })}
+            return generateOption(option, handleClick, optionIsSelected, i);
+          })}
+        </>
+      ) : (
+        <p className='text-dark mx-3 my-1'>
+          {isFilterable ? 'No Items Match Your Search' : 'No Options Provided'}
+        </p>
+      )}
     </Dropdown.Menu>
   );
 };

--- a/src/app-components/multi-select/multi-select.js
+++ b/src/app-components/multi-select/multi-select.js
@@ -49,6 +49,7 @@ const MultiSelect = ({
     }
   };
 
+  /** Execute callback when new values are selected and check if all were selected to update the UI (if necessary) */
   useEffect(() => {
     if (onChange && typeof onChange === 'function') onChange(currentSelections);
     if (withSelectAllOption) {
@@ -60,6 +61,7 @@ const MultiSelect = ({
     }
   }, [onChange, currentSelections, withSelectAllOption, setIsAllSelected]);
 
+  /** Update dropdown list of item when input component value changes. Only runs if `isFilterable` is true. */
   useEffect(() => {
     if (isFilterable) {
       if (previuosInputValue !== inputValue) {

--- a/src/app-components/multi-select/multi-select.js
+++ b/src/app-components/multi-select/multi-select.js
@@ -117,7 +117,7 @@ const MultiSelect = ({
         </>
       ) : (
         <p className='text-dark mx-3 my-1'>
-          {isFilterable ? 'No Items Match Your Search' : 'No Options Provided'}
+          {isFilterable && options.length ? 'No Items Match Your Search' : 'No Options Provided'}
         </p>
       )}
     </Dropdown.Menu>

--- a/src/app-components/multi-select/subcomponents.js
+++ b/src/app-components/multi-select/subcomponents.js
@@ -28,11 +28,19 @@ export const FilterInput = forwardRef(({
 }, ref) => {
   const [inputValue, setInputValue] = useState('');
 
+  /** Execute callback function when input value changes */
   useEffect(() => {
     if (onChange && typeof onChange === 'function') {
       onChange(inputValue);
     }
   }, [inputValue, onChange]);
+
+  /** Clear input when dropdown is closed */
+  useEffect(() => {
+    if (isHidden) {
+      setInputValue('');
+    }
+  }, [isHidden]);
 
   return (
     <div className='input-group' ref={ref} style={{ maxWidth: '400px' }}>

--- a/src/app-components/multi-select/subcomponents.js
+++ b/src/app-components/multi-select/subcomponents.js
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 
 import Button from '../button';
 
@@ -23,20 +23,44 @@ export const DropdownButton = ({
 
 export const FilterInput = forwardRef(({
   isHidden = false,
-}, ref) => (
-  <div className='input-group'>
-    <input
-      ref={ref}
-      style={{
-        maxWidth: '400px',
-        display: isHidden ? 'none' : 'inline-block',
-      }}
-      className='form-control'
-      autoFocus
-      placeholder='Filter List...'
-    />
-    <div className='input-group-append dropup'>
-      <DropdownButton isHidden={isHidden} />
+  handleClose = () => {},
+  onChange = () => {},
+}, ref) => {
+  const [inputValue, setInputValue] = useState('');
+
+  useEffect(() => {
+    if (onChange && typeof onChange === 'function') {
+      onChange(inputValue);
+    }
+  }, [inputValue, onChange]);
+
+  return (
+    <div className='input-group' ref={ref} style={{ maxWidth: '400px' }}>
+      <input
+        autoFocus
+        style={{
+          display: isHidden ? 'none' : 'inline-block',
+        }}
+        className='form-control'
+        placeholder='Filter List...'
+        value={inputValue}
+        onChange={e => setInputValue(e.target.value)}
+      />
+      <div className='input-group-append dropup'>
+        <Button
+          style={{
+            display: isHidden ? 'none' : 'initial',
+          }}
+          variant='secondary'
+          isOutline
+          title='Clear Input'
+          text='&#x2715;'
+          handleClick={() => setInputValue('')}
+        />
+      </div>
+      <div className='input-group-append dropup'>
+        <DropdownButton isHidden={isHidden} handleClick={handleClose} />
+      </div>
     </div>
-  </div>
-));
+  );
+});

--- a/src/app-components/multi-select/subcomponents.js
+++ b/src/app-components/multi-select/subcomponents.js
@@ -1,0 +1,42 @@
+import React, { forwardRef } from 'react';
+
+import Button from '../button';
+
+export const DropdownButton = ({
+  isHidden = false,
+  variant = 'info',
+  handleClick = () => {},
+  text,
+}) => (
+  <Button
+    style={{
+      display: isHidden ? 'none' : 'initial',
+    }}
+    isOutline
+    variant={variant}
+    className='dropdown-toggle'
+    title='Toggle Dropdown'
+    text={text}
+    handleClick={handleClick}
+  />
+);
+
+export const FilterInput = forwardRef(({
+  isHidden = false,
+}, ref) => (
+  <div className='input-group'>
+    <input
+      ref={ref}
+      style={{
+        maxWidth: '400px',
+        display: isHidden ? 'none' : 'inline-block',
+      }}
+      className='form-control'
+      autoFocus
+      placeholder='Filter List...'
+    />
+    <div className='input-group-append dropup'>
+      <DropdownButton isHidden={isHidden} />
+    </div>
+  </div>
+));

--- a/src/app-components/navbar.js
+++ b/src/app-components/navbar.js
@@ -73,6 +73,7 @@ const Navbar = connect(
   'doAuthLogin',
   'selectAuthIsLoggedIn',
   'selectProjectsByRoute',
+  'selectPathname',
   ({
     doAuthLogin,
     authIsLoggedIn,
@@ -81,6 +82,7 @@ const Navbar = connect(
     hideBrand,
     brand = null,
     projectsByRoute: project,
+    pathname,
   }) => {
     const navClass = classnames({
       navbar: true,
@@ -94,16 +96,30 @@ const Navbar = connect(
       'navbar-light': theme === 'light',
       'bg-light': theme === 'light',
     });
-    if (!brand && project && project.name) brand = project.name;
+
+    const isReportingActive = project && [
+      `/${project.slug}/batch-plotting`
+    ].some(path => pathname.indexOf(path) !== -1);
+
     return (
       <nav className={navClass}>
         {hideBrand ? null : (
-          <a className='navbar-brand' href={'/'}>
+          <span className='navbar-brand'>
             <strong>
-              <i className='mdi mdi-pulse pr-2'></i>
-              {brand}
+              <a href='/' className='text-white'>
+                <i className='mdi mdi-pulse pr-2'></i>
+                {brand || 'Home'}
+              </a>
             </strong>
-          </a>
+            {project && project.name && (
+              <>
+                <i className='mdi mdi-chevron-right pl-2 pr-2' />
+                <span className='text-white default-cursor'>
+                  {project.name}
+                </span>
+              </>
+            )}
+          </span>
         )}
         <button
           className='navbar-toggler'
@@ -122,14 +138,14 @@ const Navbar = connect(
                 <NavItem href={`/${project.slug}/manager`}>
                   Inventory Manager
                 </NavItem>
-                <NavItem hidden={false} href={`/${project.slug}/explore`}>
+                <NavItem href={`/${project.slug}/explore`}>
                   Explorer
                 </NavItem>
                 <RoleFilter allowRoles={[`${project.slug.toUpperCase()}.*`]}>
                   <NavItem href={`/${project.slug}/upload`}>Uploader</NavItem>
                 </RoleFilter>
                 <Dropdown.Menu
-                  dropdownClasses={['nav-item pointer']}
+                  dropdownClasses={[`nav-item pointer${isReportingActive ? ' active': '' }`]}
                   menuClasses={['dropdown-menu-right']}
                   customContent={<span className='nav-link'>Reporting</span>}
                 >

--- a/src/app-components/navbar.js
+++ b/src/app-components/navbar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'redux-bundler-react';
-import { classnames } from '../utils';
+import { classArray } from '../utils';
 import Dropdown from './dropdown';
 import RoleFilter from './role-filter';
 
@@ -41,31 +41,28 @@ const ProfileMenu = connect(
 const NavItem = connect(
   'selectPathname',
   ({ pathname, href, handler, children, hidden }) => {
-    if (hidden) return null;
+    const cls = classArray([
+      'pointer',
+      'nav-item',
+      pathname.indexOf(href) !== -1 && href !== '/' && 'active',
+    ]);
+
     const handleClick = (e) => {
       if (handler && typeof handler === 'function') handler(e);
     };
-    const cls = classnames({
-      pointer: true,
-      'nav-item': true,
-      active: pathname.indexOf(href) !== -1 && href !== '/',
-    });
-    if (href) {
-      return (
+
+    return !hidden ?
+      handler ? (
+        <li className={cls} onClick={handleClick}>
+          <span className='nav-link'>{children}</span>
+        </li>
+      ) : (
         <li className={cls}>
           <a className='nav-link' href={href}>
             {children}
           </a>
         </li>
-      );
-    }
-    if (handler) {
-      return (
-        <li className={cls} onClick={handleClick}>
-          <span className='nav-link'>{children}</span>
-        </li>
-      );
-    }
+      ) : null;
   }
 );
 
@@ -84,18 +81,13 @@ const Navbar = connect(
     projectsByRoute: project,
     pathname,
   }) => {
-    const navClass = classnames({
-      navbar: true,
-      'fixed-top': fixed,
-      'navbar-expand-lg': true,
-      'navbar-dark':
-        theme === 'primary' || theme === 'dark' || theme === 'transparent',
-      'bg-primary': theme === 'primary',
-      'bg-dark': theme === 'dark',
-      'bg-transparent': theme === 'transparent',
-      'navbar-light': theme === 'light',
-      'bg-light': theme === 'light',
-    });
+    const navClass = classArray([
+      'navbar',
+      'navbar-expand-lg',
+      fixed && 'fixed-top',
+      theme === 'light' ? 'navbar-light' : 'navbar-dark',
+      `bg-${theme}`,
+    ]);
 
     const isReportingActive = project && [
       `/${project.slug}/batch-plotting`

--- a/src/app-components/upload-button.js
+++ b/src/app-components/upload-button.js
@@ -2,6 +2,7 @@ import React, { useRef } from 'react';
 import { connect } from 'redux-bundler-react';
 
 import Button from './button';
+import { classArray } from '../utils';
 
 export default connect(
   'doUploadQueueCsv',
@@ -26,11 +27,11 @@ export default connect(
       doUploadQueueCsv(inputEl.current.files[0]);
     };
 
-    const iconClassNames = [
+    const iconClassNames = classArray([
       'mdi',
       `${icon}`,
       'pr-2',
-    ].join(' ');
+    ]);
 
     return (
       <>

--- a/src/app-pages/group/instrument-picker.js
+++ b/src/app-pages/group/instrument-picker.js
@@ -2,28 +2,24 @@ import React, { useState } from 'react';
 import { connect } from 'redux-bundler-react';
 
 import { ModalFooter, ModalHeader } from '../../app-components/modal';
+import MultiSelect from '../../app-components/multi-select';
 
 export default connect(
-  'doModalClose',
   'doInstrumentGroupInstrumentsSave',
   'selectInstrumentsItemsObject',
   'selectInstrumentGroupInstrumentsItemsObject',
   ({
-    doModalClose,
     doInstrumentGroupInstrumentsSave,
     instrumentsItemsObject: instruments,
     instrumentGroupInstrumentsItemsObject: groupInstruments,
   }) => {
-    const [instrumentSlug, setInstrumentSlug] = useState('');
+    const [instrumentSlugs, setInstrumentSlugs] = useState([]);
 
-    const handleSelect = (e) => {
-      setInstrumentSlug(e.target.value);
-    };
-
-    const handleSave = (e) => {
-      e.preventDefault();
-      const instrument = instruments[instrumentSlug];
-      doInstrumentGroupInstrumentsSave(instrument, doModalClose, true, true);
+    const handleSave = (_e) => {
+      instrumentSlugs.forEach(instrumentSlug => {
+        const instrument = instruments[instrumentSlug];
+        doInstrumentGroupInstrumentsSave(instrument, null, true, true);
+      });
     };
 
     const currentMembers = Object.keys(groupInstruments);
@@ -36,35 +32,25 @@ export default connect(
       });
 
     return (
-      <div className='modal-content'>
-        <form id='instrument-picker' onSubmit={handleSave}>
-          <ModalHeader title='Choose Instrument' />
-          <section className='modal-body'>
-            <div className='form-group'>
-              <label>Type</label>
-              <select
-                className='form-control'
-                value={instrumentSlug}
-                onChange={handleSelect}
-              >
-                {instrumentSlug ? null : (
-                  <option value=''>Select one...</option>
-                )}
-                {options.map((opt, i) => (
-                  <option key={i} value={opt.slug}>
-                    {opt.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </section>
-          <ModalFooter
-            saveIsSubmit
-            customClosingLogic
-            saveText='Save changes'
-            onCancel={() => doModalClose()}
+      <div className='modal-content overflow-visible'>
+        <ModalHeader title='Choose Instruments' />
+        <section className='modal-body overflow-visible'>
+          <MultiSelect
+            text={`Select Instruments (${instrumentSlugs.length} selected)`}
+            isFilterable
+            withSelectAllOption
+            onChange={val => setInstrumentSlugs(val)}
+            options={options.map(opt => ({
+              text: opt.name,
+              value: opt.slug,
+            }))}
           />
-        </form>
+        </section>
+        <ModalFooter
+          showCancelButton
+          saveText='Add'
+          onSave={() => handleSave()}
+        />
       </div>
     );
   }

--- a/src/app-pages/instrument/alert/alert-editor.js
+++ b/src/app-pages/instrument/alert/alert-editor.js
@@ -5,6 +5,7 @@ import AlertForm from './alert-editor-form';
 import AlertFormModal from '../../manager/alert-form';
 import AlertConfigSettings from '../../manager/alert-config-form';
 import Button from '../../../app-components/button';
+import { classArray } from '../../../utils';
 
 export default connect(
   'selectAlertConfigsByRouteByInstrumentId',
@@ -24,11 +25,11 @@ export default connect(
     };
 
     const alertListItem = (a, i) => {
-      const classes = [
+      const classes = classArray([
         'list-group-item',
         'list-group-item-action',
         a && selectedAlert && a.id === selectedAlert.id ? 'active' : '',
-      ].join(' ');
+      ]);
 
       return (
         <li

--- a/src/app-pages/profile/userProfile.css
+++ b/src/app-pages/profile/userProfile.css
@@ -8,7 +8,3 @@
   overflow-x: auto;
   margin-bottom: 20px;
 }
-
-.overflow-visible {
-  overflow: visible !important;
-}

--- a/src/app-pages/profile/userProfile.css
+++ b/src/app-pages/profile/userProfile.css
@@ -1,9 +1,14 @@
 .user-container {
   background-color: #e6e6e6;
+  min-height: 100vh;
 }
 
 .limit-height {
   max-height: 80vh;
   overflow-x: auto;
   margin-bottom: 20px;
+}
+
+.overflow-visible {
+  overflow: visible !important;
 }

--- a/src/app-pages/profile/userProfile.js
+++ b/src/app-pages/profile/userProfile.js
@@ -6,14 +6,25 @@ import Navbar from '../../app-components/navbar';
 import Tab from '../../app-components/tab';
 
 import './userProfile.css';
+import MultiSelect from '../../app-components/multi-select';
 
 const urlify = str => str.toLowerCase().split(' ').join('-');
 
 const buildProjectContent = (projects = []) => {
-  if (!projects.length) return <p>No Projects!</p>;
+  if (projects.length) return <p>No Projects!</p>;
 
   return (
     <div>
+      <MultiSelect
+        isFilterable
+        menuClasses='overflow-menu'
+        options={[
+          { value: 1 },
+          { value: 2 },
+          { value: 3 },
+          { value: 4 },
+        ]}
+      />
       Favorited Project List goes here!
     </div>
   );
@@ -75,7 +86,7 @@ const UserProfile = connect(
             </div>
             <div className='col-8'>
               <div className='card p-0 mt-2'>
-                <Tab.Container tabs={tabs} tabListClass='card-header pb-0' contentClass='card-body limit-height py-0' />
+                <Tab.Container tabs={tabs} tabListClass='card-header pb-0' contentClass='card-body limit-height py-0 overflow-visible' />
               </div>
             </div>
           </div>

--- a/src/app-pages/profile/userProfile.js
+++ b/src/app-pages/profile/userProfile.js
@@ -10,7 +10,7 @@ import './userProfile.css';
 const urlify = str => str.toLowerCase().split(' ').join('-');
 
 const buildProjectContent = (projects = []) => {
-  if (projects.length) return <p>No Projects!</p>;
+  if (!projects.length) return <p>No Projects!</p>;
 
   return (
     <div>
@@ -75,7 +75,7 @@ const UserProfile = connect(
             </div>
             <div className='col-8'>
               <div className='card p-0 mt-2'>
-                <Tab.Container tabs={tabs} tabListClass='card-header pb-0' contentClass='card-body limit-height py-0 overflow-visible' />
+                <Tab.Container tabs={tabs} tabListClass='card-header pb-0' contentClass='card-body limit-height py-0' />
               </div>
             </div>
           </div>

--- a/src/app-pages/profile/userProfile.js
+++ b/src/app-pages/profile/userProfile.js
@@ -6,7 +6,6 @@ import Navbar from '../../app-components/navbar';
 import Tab from '../../app-components/tab';
 
 import './userProfile.css';
-import MultiSelect from '../../app-components/multi-select';
 
 const urlify = str => str.toLowerCase().split(' ').join('-');
 
@@ -15,16 +14,6 @@ const buildProjectContent = (projects = []) => {
 
   return (
     <div>
-      <MultiSelect
-        isFilterable
-        menuClasses='overflow-menu'
-        options={[
-          { value: 1 },
-          { value: 2 },
-          { value: 3 },
-          { value: 4 },
-        ]}
-      />
       Favorited Project List goes here!
     </div>
   );

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -29,6 +29,10 @@ $error-color: #f04124;
   cursor: pointer;
 }
 
+.default-cursor {
+  cursor: default;
+}
+
 .not-allowed {
   cursor: not-allowed !important;
 }
@@ -47,6 +51,11 @@ footer.modal-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.nav-item.active {
+  border-top: solid 2px white;
+  font-weight: 700;
 }
 
 .timeline-list-item {

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -25,6 +25,10 @@ $error-color: #f04124;
   display: none;
 }
 
+.overflow-visible {
+  overflow: visible !important;
+}
+
 .pointer {
   cursor: pointer;
 }

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -64,7 +64,7 @@ footer.modal-footer {
   padding-left: 0;
   padding-bottom: 10px;
 
-  ::before {
+  &::before {
     left: -8px;
     top: 2px;
     position: relative;
@@ -79,23 +79,23 @@ footer.modal-footer {
     border: 3px solid #69b6d5;
   }
 
-  .active::before {
+  &.active::before {
     border-color: $success-color;
   }
 
-  .inactive::before {
+  &.inactive::before {
     border-color: $inactive-color;
   }
 
-  .abandoned::before {
+  &.abandoned::before {
     border-color: $inactive-color;
   }
 
-  .destroyed::before {
+  &.destroyed::before {
     border-color: $error-color;
   }
 
-  .lost::before {
+  &.lost::before {
     border-color: $warning-color;
   }
 }

--- a/src/customHooks/useOutsideEventHandle.js
+++ b/src/customHooks/useOutsideEventHandle.js
@@ -6,8 +6,19 @@ import { useEffect } from 'react';
 const useOutsideEventHandle = (event, ref, callback) => {
   useEffect(() => {
     const handleEventOutside = event => {
-      if (ref.current && !ref.current.contains(event.target)) {
-        callback();
+      if (Array.isArray(ref)) {
+        // console.log('trying, one sec...');
+        let contained = false;
+        ref.forEach(r => {
+          // console.log('r.current is...', r.current);
+          if (r.current && r.current.contains(event.target)) contained = true;
+        });
+
+        if (!contained) callback();
+      } else {
+        if (ref.current && !ref.current.contains(event.target)) {
+          callback();
+        }
       }
     };
 

--- a/src/customHooks/useOutsideEventHandle.js
+++ b/src/customHooks/useOutsideEventHandle.js
@@ -7,10 +7,9 @@ const useOutsideEventHandle = (event, ref, callback) => {
   useEffect(() => {
     const handleEventOutside = event => {
       if (Array.isArray(ref)) {
-        // console.log('trying, one sec...');
         let contained = false;
+
         ref.forEach(r => {
-          // console.log('r.current is...', r.current);
           if (r.current && r.current.contains(event.target)) contained = true;
         });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,8 @@ exports.classnames = (opts) => Object.keys(opts)
   .map((key) => !!opts[key] ? key : '')
   .join(' ');
 
+exports.classArray = (arr) => arr.filter(e => e).join(' ');
+
 exports.formatBytes = (bytes) => {
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
   if (bytes === 0) return 'n/a';


### PR DESCRIPTION
- Enhance component `MultiSelect` to include a prop `isFilterable`. This property transforms the multiselect into an input field when the dropdown list is open, allowing the user to enter text to limit the amount of items shown in the list. If the input doesn't result in any options shown, a message is shown to the user explaining their search doesn't match any items. If the select all option is displayed, it will always show while the user has a valid search, and will still select **ALL** options, not just the visible options.

- Add util function `classArray` to allow passing of an array of strings, to be quickly transformed into a single string for classNames.

- Implement new filterable multiselect in the `Add Existing Instruments` modal as a first pass. If feedback is good, can be implemented in other spots that make sense for it.

- Enhance `useOutsideEventHandle` to allow passing an array of refs that can be checked for, allowing for a more customizable target frame.

See https://github.com/USACE/instrumentation/issues/44