### PR TITLE
bugfix/filter-select

### DIFF
--- a/src/app-components/filter-select.js
+++ b/src/app-components/filter-select.js
@@ -1,5 +1,6 @@
 
 import React, { useEffect, useState } from 'react';
+import isEqual from 'lodash.isequal';
 
 import Dropdown from './dropdown';
 import Icon from './icon';
@@ -47,7 +48,9 @@ const FilterSelect = ({
   }, [inputVal, previousVal, items, onChange, setFilteredList]);
 
   useEffect(() => {
-    if (items !== previousItems) {
+    console.log('test items:', items);
+    console.log('test previousItems: ', previousItems);
+    if (!isEqual(items, previousItems)) {
       setFilteredList(items);
     }
   }, [items, previousItems]);

--- a/src/app-components/filter-select.js
+++ b/src/app-components/filter-select.js
@@ -48,8 +48,6 @@ const FilterSelect = ({
   }, [inputVal, previousVal, items, onChange, setFilteredList]);
 
   useEffect(() => {
-    console.log('test items:', items);
-    console.log('test previousItems: ', previousItems);
     if (!isEqual(items, previousItems)) {
       setFilteredList(items);
     }


### PR DESCRIPTION
Filter Select was doing a basic `==` comparison between two complex objects which will always eval to `false`.
Updated to include the `isEqual` function from lodash to check the equality