### PR TITLE
bugfix/overflow-explorer-panels

### DIFF
--- a/src/app-pages/explorer/explorer.js
+++ b/src/app-pages/explorer/explorer.js
@@ -60,7 +60,7 @@ export default connect(
             <MapTools />
             <MapLegend />
           </Panel>
-          <Panel>
+          <Panel className='overflow-auto'>
             <Visualizations />
           </Panel>
         </PanelGroup>

--- a/src/app-pages/explorer/panel.js
+++ b/src/app-pages/explorer/panel.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Panel = ({ children }) => (
-  <div style={{ position: 'absolute', top: 0, right: 0, left: 0, bottom: 0 }}>
+const Panel = ({ children, className = '' }) => (
+  <div className={className} style={{ position: 'absolute', top: 0, right: 0, left: 0, bottom: 0 }}>
     {children}
   </div>
 );


### PR DESCRIPTION
- add className prop to panel
- add overflow-auto class to visualizations panel to allow overflow to scroll if necessary