### PR TITLE
Complete SOW A.1.3/A.2.1/B.3.2. Refactor existing changes.

### DIFF
--- a/src/app-bundles/create-rest-bundle.js
+++ b/src/app-bundles/create-rest-bundle.js
@@ -1,22 +1,35 @@
 import { createSelector } from 'redux-bundler';
 
 /**
- * Replace any :item.* values in the url with the actual value from the item
+ * Replace any :.* values in the url with the actual value from the item.
+ * 
+ * Three flavors of syntax are permitted for substitution:
+ * 1. `/building/:item.pathParamName`
+ * 2. `/building/:item.pathParamName/other`
+ * 3. `/building/path?queryVar={:item.pathParamName}`
+ * 
+ * The third flavor is permissible anywhere in the string. For example, one
+ * can write `/building_{:pathParam}/other`. If `item = { pathParam: 'test' }`,
+ * this would produce `/building_test/other`.
  */
 const decorateUrlWithItem = (urlTemplate, item) => {
-  const regex = /(:.*?)(\/|$)/gi;
+  const prefix = ':item.';
+  const regex = /(:item\.{1,}?)(?:\/|$)|\{(:item\..{1,}?)\}/gi;
   let url = urlTemplate;
   let m;
-  while ((m = regex.exec(urlTemplate)) != null) {
-    if (m.index === regex.lastIndex) {
-      regex.lastIndex++;
-    }
-    const param = m[1];
-    if (param.indexOf('item') !== -1) {
-      const key = param.split('.')[1];
-      url = url.replace(param, item[key]);
-    }
+  while ((m = regex.exec(urlTemplate)) !== null) {
+    const matched = m[0];
+
+    // In the case our group starts with {, we must replace the entire group.
+    // In the case that our group is a /:param/-type, we must replace just the
+    // :param portion (excluding the trailing forward slash). In both cases,
+    // the parameter ID is the match's contained group, which always starts with
+    // ':'.
+    const toReplace = matched.startsWith('{') ? m[0] : m[1];
+    const key = (matched.startsWith('{') ? m[2] : m[1]).slice(prefix.length);
+    url = url.replace(toReplace, (item && item[key] ? item[key] : ''));
   }
+  url = url.replace(/\{|\}/g, '');
   return url;
 };
 
@@ -252,8 +265,7 @@ const createRestBundle = (opts) => {
         };
       },
 
-      // 
-      [doFetch]: () => ({ dispatch, store, apiGet }) => {
+      [doFetch]: (item) => ({ dispatch, store, apiGet }) => {
         dispatch({
           type: actions.FETCH_STARTED,
           payload: {
@@ -275,7 +287,7 @@ const createRestBundle = (opts) => {
           return;
         }
 
-        const url = store[selectGetUrl]();
+        const url = decorateUrlWithItem(store[selectGetUrl](), item);
         let fetchCount = store[selectFetchCount]();
         const isStale = store[selectIsStale]();
         const lastResource = store[selectLastResource]();
@@ -283,7 +295,7 @@ const createRestBundle = (opts) => {
         const flags = store[selectFlags]();
         const items = store[selectItemsObject]();
 
-        if (url.indexOf('/:') !== -1) {
+        if (url.indexOf('/:') !== -1 || url.indexOf('{:') !== -1) {
           // if we haven't filled in all of our params then bail
           dispatch({
             type: actions.FETCH_ABORT,

--- a/src/app-bundles/inclinometer-measurements.js
+++ b/src/app-bundles/inclinometer-measurements.js
@@ -34,7 +34,7 @@ export default createRestBundle({
   },
 
   addons : {
-    doDeleteInclinometerMeasurement: ({
+    doInclinometerMeasurementDelete: ({
       timeseriesId,
       date,
     }) => ({ dispatch, store, apiDelete }) => {

--- a/src/app-bundles/inclinometer-measurements.js
+++ b/src/app-bundles/inclinometer-measurements.js
@@ -1,18 +1,15 @@
 import createRestBundle from './create-rest-bundle';
 
-const afterDate = '1900-01-01T00:00:00.00Z';
-const beforeDate = '2025-01-01T00:00:00.00Z';
-
 export default createRestBundle({
   name: 'inclinometerMeasurements',
   uid: 'timeseries_id',
   staleAfter: 10000,
   persist: false,
   routeParam: '',
-  getTemplate: `/timeseries/:timeseriesId/inclinometer_measurements?before=${beforeDate}&after=${afterDate}`,
+  getTemplate: '/timeseries/:timeseriesId/inclinometer_measurements?before={:item.before}&after={:item.after}',
   putTemplate: '',
   postTemplate: '',
-  deleteTemplate: '',
+  deleteTemplate: '/timeseries/:timeseriesId/inclinometer_measurements?time={:item.date}',
   fetchActions: [],
   forceFetchActions: [
     'INSTRUMENTTIMESERIES_SET_ACTIVE_ID',
@@ -32,32 +29,4 @@ export default createRestBundle({
 
     return whitelist.includes(hash) || pathnameWhitelist.some(elem => url.pathname.includes(elem));
   },
-
-  addons : {
-    doInclinometerMeasurementDelete: ({
-      timeseriesId,
-      date,
-    }) => ({ dispatch, store, apiDelete }) => {
-      dispatch({ type: 'DELETE_INCLINOMETER_MEASUREMENT_START', payload: {} });
-      
-      const url = `/timeseries/${timeseriesId}/inclinometer_measurements?time=${date}`;
-      const delItem = [{'timeseries_id' : timeseriesId, 'time' : date}];
-
-      apiDelete(url, (_err, body) => {
-        dispatch({
-          type: 'INCLINOMETER_MEASUREMENT_ITEM_TO_DELETE',
-          payload: {
-            ...delItem,
-            ...{
-              _isLoading: false,
-              _isSaving: false,
-              _lastResource: url,
-              _abortReason: null,
-            }
-          },
-        });
-        dispatch({ type: 'DELETE_INCLINOMETER_MEASUREMENT_FINISHED', payload: {} });
-      });
-    },
-  }
 });

--- a/src/app-bundles/inclinometer-measurements.js
+++ b/src/app-bundles/inclinometer-measurements.js
@@ -6,9 +6,13 @@ export default createRestBundle({
   staleAfter: 10000,
   persist: false,
   routeParam: '',
-  getTemplate: '/timeseries/:timeseriesId/inclinometer_measurements?before={:item.before}&after={:item.after}',
+
+  // TODO: default before and after time periods should be implemented on
+  // the backend.
+  getTemplate: '/timeseries/:timeseriesId/inclinometer_measurements?before=2025-01-01T00:00:00.00Z&after=1900-01-01T00:00:00.00Z',
+  
   putTemplate: '',
-  postTemplate: '',
+  postTemplate: '/timeseries/:timeseriesId/inclinometer_measurements',
   deleteTemplate: '/timeseries/:timeseriesId/inclinometer_measurements?time={:item.date}',
   fetchActions: [],
   forceFetchActions: [

--- a/src/app-bundles/index.js
+++ b/src/app-bundles/index.js
@@ -74,7 +74,7 @@ export default composeBundles(
   createJwtApiBundle({
     root:
       process.env.NODE_ENV === 'development'
-        ? 'http://localhost:8082'
+        ? 'http://localhost:80'
         : process.env.REACT_APP_API_URL,
     tokenSelector: 'selectAuthTokenRaw',
     unless: {

--- a/src/app-bundles/time-series-measurements-bundle.js
+++ b/src/app-bundles/time-series-measurements-bundle.js
@@ -66,7 +66,7 @@ export default createRestBundle({
       });
     },
     
-    doDeleteTimeseriesMeasurement: ({
+    doTimeseriesMeasurementDelete: ({
       timeseriesId,
       date,
     }) => ({ dispatch, store, apiDelete }) => {

--- a/src/app-bundles/time-series-measurements-bundle.js
+++ b/src/app-bundles/time-series-measurements-bundle.js
@@ -12,7 +12,7 @@ export default createRestBundle({
   getTemplate: `/timeseries/:timeseriesId/measurements?after=${afterDate}&before=${beforeDate}`,
   putTemplate: '',
   postTemplate: '/projects/:projectId/timeseries_measurements',
-  deleteTemplate: '/timeseries/:timeseriesId/measurements',
+  deleteTemplate: '/timeseries/:timeseriesId/measurements?time={:date}',
   fetchActions: [],
   forceFetchActions: [
     'INSTRUMENTTIMESERIES_SET_ACTIVE_ID',
@@ -48,7 +48,7 @@ export default createRestBundle({
         new Array(body).forEach(item => itemsById[item['timeseries_id']] = item);
 
         dispatch({
-          type: 'TIMSERIES_MEASUREMENTS_UPDATED_ITEM',
+          type: 'TIMESERIES_MEASUREMENTS_UPDATED_ITEM',
           payload: {
             ...itemsById,
             ...flags,
@@ -65,42 +65,11 @@ export default createRestBundle({
         dispatch({ type: 'TIMESERIES_FETCH_BY_ID_FINISHED', payload: {} });
       });
     },
-    
-    doTimeseriesMeasurementDelete: ({
-      timeseriesId,
-      date,
-    }) => ({ dispatch, store, apiDelete }) => {
-      dispatch({ type: 'DELETE_TIMESERIES_MEASUREMENT_START', payload: {} });
-      
-      const url = `/timeseries/${timeseriesId}/measurements?time=${date}`;
-      const flags = store['selectTimeseriesMeasurementsFlags']();
-      const delItem = [{'timeseries_id' : timeseriesId, 'time' : date}];
-      let fetchCount = store['selectTimeseriesMeasurementsFetchCount']();
-
-      apiDelete(url, (_err, body) => {
-        dispatch({
-          type: 'TIMESERIES_MEASUREMENT_ITEM_TO_DELETE',
-          payload: {
-            ...delItem,
-            ...flags,
-            ...{
-              _isLoading: false,
-              _isSaving: false,
-              _fetchCount: ++fetchCount,
-              _lastFetch: new Date(),
-              _lastResource: url,
-              _abortReason: null,
-            }
-          },
-        });
-        dispatch({ type: 'DELETE_TIMESERIES_MEASUREMENT_FINISHED', payload: {} });
-      });
-    },
   },
 
   reduceFurther: (state, { type, payload }) => {
     switch (type) {
-      case 'TIMSERIES_MEASUREMENTS_UPDATED_ITEM':
+      case 'TIMESERIES_MEASUREMENTS_UPDATED_ITEM':
         return Object.assign({}, state, payload);
       default:
         return state;

--- a/src/app-pages/instrument/timeseries/timeseries.js
+++ b/src/app-pages/instrument/timeseries/timeseries.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'redux-bundler-react';
 import DatePicker from 'react-datepicker';
 import { AgGridReact } from '@ag-grid-community/react';
@@ -14,7 +14,6 @@ import TimeseriesListItem from './timeseries-list-item';
 
 import '../../../css/grids.scss';
 import './timeseries.css';
-import { isObjectLike } from 'lodash';
 
 export default connect(
   'doModalOpen',
@@ -24,13 +23,13 @@ export default connect(
   'selectNonComputedTimeseriesItemsByRoute',
   'selectTimeseriesMeasurementsItemsObject',
   'selectInclinometerMeasurementsItemsObject',
-  'doDeleteTimeseriesMeasurement',
+  'doTimeseriesMeasurementDelete',
   'doTimeseriesMeasurementsSave',
-  'doDeleteInclinometerMeasurement',
+  'doInclinometerMeasurementDelete',
   ({
     doModalOpen,
-    doDeleteTimeseriesMeasurement,
-    doDeleteInclinometerMeasurement,
+    doTimeseriesMeasurementDelete,
+    doInclinometerMeasurementDelete,
     doTimeseriesMeasurementsSave,
     doInstrumentTimeseriesSetActiveId,
     projectsByRoute: project,
@@ -77,11 +76,11 @@ export default connect(
         const rowData = grid.api.getSelectedNodes()[0].data;
         const time = rowData.time;
         isInclinometer ? 
-          doDeleteInclinometerMeasurement({
+          doInclinometerMeasurementDelete({
             timeseriesId: activeTimeseries,
             date: time
           }) :
-          doDeleteTimeseriesMeasurement({
+          doTimeseriesMeasurementDelete({
             timeseriesId: activeTimeseries,
             date: time
           });
@@ -97,7 +96,7 @@ export default connect(
         const { node, data } = cell;
         data.value = new Number(data.value);
         if(cell.colDef.field == 'time') {
-          doDeleteTimeseriesMeasurement({
+          doTimeseriesMeasurementDelete({
             timeseriesId: activeTimeseries,
             date: cell.oldValue
           });

--- a/src/app-pages/instrument/timeseries/timeseries.js
+++ b/src/app-pages/instrument/timeseries/timeseries.js
@@ -25,11 +25,11 @@ export default connect(
   'selectInclinometerMeasurementsItemsObject',
   'doTimeseriesMeasurementDelete',
   'doTimeseriesMeasurementsSave',
-  'doInclinometerMeasurementDelete',
+  'doInclinometerMeasurementsDelete',
   ({
     doModalOpen,
     doTimeseriesMeasurementDelete,
-    doInclinometerMeasurementDelete,
+    doInclinometerMeasurementsDelete,
     doTimeseriesMeasurementsSave,
     doInstrumentTimeseriesSetActiveId,
     projectsByRoute: project,
@@ -76,7 +76,7 @@ export default connect(
         const rowData = grid.api.getSelectedNodes()[0].data;
         const time = rowData.time;
         isInclinometer ? 
-          doInclinometerMeasurementDelete({
+          doInclinometerMeasurementsDelete({
             timeseriesId: activeTimeseries,
             date: time
           }) :

--- a/src/app-pages/instrument/timeseries/timeseries.js
+++ b/src/app-pages/instrument/timeseries/timeseries.js
@@ -23,12 +23,12 @@ export default connect(
   'selectNonComputedTimeseriesItemsByRoute',
   'selectTimeseriesMeasurementsItemsObject',
   'selectInclinometerMeasurementsItemsObject',
-  'doTimeseriesMeasurementDelete',
+  'doTimeseriesMeasurementsDelete',
   'doTimeseriesMeasurementsSave',
   'doInclinometerMeasurementsDelete',
   ({
     doModalOpen,
-    doTimeseriesMeasurementDelete,
+    doTimeseriesMeasurementsDelete,
     doInclinometerMeasurementsDelete,
     doTimeseriesMeasurementsSave,
     doInstrumentTimeseriesSetActiveId,
@@ -80,8 +80,7 @@ export default connect(
             timeseriesId: activeTimeseries,
             date: time
           }) :
-          doTimeseriesMeasurementDelete({
-            timeseriesId: activeTimeseries,
+          doTimeseriesMeasurementsDelete({
             date: time
           });
         setDidDelete(!didDelete);
@@ -96,8 +95,7 @@ export default connect(
         const { node, data } = cell;
         data.value = new Number(data.value);
         if(cell.colDef.field == 'time') {
-          doTimeseriesMeasurementDelete({
-            timeseriesId: activeTimeseries,
+          doTimeseriesMeasurementsDelete({
             date: cell.oldValue
           });
         }


### PR DESCRIPTION
This PR is an extension of #128 to complete the tasking originally described in the PR, as well as to refactor and improve existing changes made in its implementation.
* Rather than roll custom functions for CRUD operations, integrates with existing `create-rest-bundle` semantics.
  * To this end, adds an alternative parameter insertion pattern `{:item.paramName}` to allow for query parameters.
* Reverts configuration changes, such as the expected backend port.
* Refactors existing changes for syntactical clarity (e.g., rather than `for`/`push`, use `map`).

This PR should be merged into #128, then said PR should be merged to branch `develop`.