### PR TITLE
use OSM map layer for default

### DIFF
--- a/src/ol-controls/basemap-picker.js
+++ b/src/ol-controls/basemap-picker.js
@@ -6,6 +6,14 @@ import './basemap-picker.css';
 
 const basemaps = [
   {
+    id: 'OpenStreetMap',
+    name: 'OpenStreetMap',
+    url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    maxZoom: 19,
+    attributions:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+  },
+  {
     id: 'CartoDBPositron',
     name: 'CartoDB Positron',
     url:
@@ -22,14 +30,6 @@ const basemaps = [
     attributions:
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://cartodb.com/attributionss">CartoDB</a>',
     maxZoom: 19,
-  },
-  {
-    id: 'OpenStreetMap',
-    name: 'OpenStreetMap',
-    url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-    maxZoom: 19,
-    attributions:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
   },
   {
     id: 'MapBoxStreets',
@@ -121,7 +121,6 @@ class BasemapControl extends Control {
           (b) =>
             new XYZ({
               url: b.url,
-              crossOrigin: true,
               attributions: b.attributions,
               maxZoom: b.maxZoom,
             })


### PR DESCRIPTION
In some cases, certain layers return with CORS errors due to security software when using devices that access this app in production. This can be fixed by opening another browser tab and authenticating external requests. However this requires an extra step from the user.

This changes the default layer in the map to OSM, which doesn't have this issue.

It also removes the `crossOrigin` option, which should only accept a string type
https://openlayers.org/en/latest/apidoc/module-ol_source_XYZ.html